### PR TITLE
Fix: Remove `meet.ffmuc.net` server not embeddable anymore

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.2.3 (Unreleased)
+--------------------
+- Fix: Remove `meet.ffmuc.net` server ([not embeddable anymore](https://ffmuc.net/freifunk/infrastruktur/community/2026/03/19/iframe-embedding-einschraenkungen/#en))
+
 1.2.2 (July 8, 2026)
 --------------------
 - Fix #49: "Open in new window?" not working on mobile app

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 1.2.3 (Unreleased)
 --------------------
-- Fix: Remove `meet.ffmuc.net` server ([not embeddable anymore](https://ffmuc.net/freifunk/infrastruktur/community/2026/03/19/iframe-embedding-einschraenkungen/#en))
+- Fix #55: Remove `meet.ffmuc.net` server ([not embeddable anymore](https://ffmuc.net/freifunk/infrastruktur/community/2026/03/19/iframe-embedding-einschraenkungen/#en))
 
 1.2.2 (July 8, 2026)
 --------------------

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -8,7 +8,6 @@ use yii\base\Model;
 class SettingsForm extends Model
 {
     public const DEFAULT_JITSI_DOMAINS = [
-        'meet.ffmuc.net',
         'kmeet.infomaniak.com',
         'jitsi.hamburg.ccc.de',
     ];

--- a/module.json
+++ b/module.json
@@ -7,7 +7,7 @@
     "conference",
     "jitsi"
   ],
-  "version": "1.2.2",
+  "version": "1.2.3",
   "humhub": {
     "minVersion": "1.18"
   },


### PR DESCRIPTION
https://ffmuc.net/freifunk/infrastruktur/community/2026/03/19/iframe-embedding-einschraenkungen/#en

https://github.com/humhub/app-internal/issues/161